### PR TITLE
fix(babel): disable cleanupIDs plugin to avoid conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 docs/public
 
 .vercel
+.DS_Store

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -28,6 +28,20 @@ module.exports = {
         transformFunctions: ['require', 'require.context'],
         resolvePath
       }
+    ],
+    [
+      'inline-react-svg',
+      {
+        svgo: {
+          plugins: [
+            {
+              cleanupIDs: {
+                minify: false
+              }
+            }
+          ]
+        }
+      }
     ]
   ]
 }

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -28,20 +28,6 @@ module.exports = {
         transformFunctions: ['require', 'require.context'],
         resolvePath
       }
-    ],
-    [
-      'inline-react-svg',
-      {
-        svgo: {
-          plugins: [
-            {
-              cleanupIDs: {
-                minify: false
-              }
-            }
-          ]
-        }
-      }
     ]
   ]
 }

--- a/packages/andive/.babelrc
+++ b/packages/andive/.babelrc
@@ -8,7 +8,9 @@
       "inline-react-svg",
       {
         "svgo": {
-          "plugins": [{"cleanupIDs": {"minify": false}}]
+          // cleanupIDs minify and can create inline ids conflict
+          // See https://github.com/svg/svgo/issues/674 for more informations
+          "plugins": [{"cleanupIDs": false}]
         }
       }
     ]

--- a/packages/andive/.babelrc
+++ b/packages/andive/.babelrc
@@ -1,13 +1,16 @@
 {
-    "presets": [
-        "@babel/preset-typescript",
-        "@babel/preset-react",
-        "@babel/preset-env"
-    ],
-    "plugins": [
-        "@babel/proposal-class-properties",
-        "@babel/proposal-object-rest-spread",
-        "@babel/plugin-proposal-export-default-from",
-        "inline-react-svg"
+  "presets": ["@babel/preset-typescript", "@babel/preset-react", "@babel/preset-env"],
+  "plugins": [
+    "@babel/proposal-class-properties",
+    "@babel/proposal-object-rest-spread",
+    "@babel/plugin-proposal-export-default-from",
+    [
+      "inline-react-svg",
+      {
+        "svgo": {
+          "plugins": [{"cleanupIDs": {"minify": false}}]
+        }
+      }
     ]
+  ]
 }


### PR DESCRIPTION
J'ai eu un petit problème qu'on a résolu avec @gijosso & @rhavenz ce matin sur un layer SVG qui n'apparaissait pas, finalement on s'est rendu compte que les svg en inline n'étaient pas scopés et que cela pouvait créer un conflit

En rajoutant l’illustration Check de mon ticket A4H j’ai remarqué que le cercle violet apparaissait bien dans la preview mac mais pas dans storybook, après un peu de recherche on s’est rendu compte que si on ajoutait l’illustration en premier dans la story ca marchait bien, mais pas en dernier! Finalement on a compris que ca venait de la réécriture des ids (minify) du babel-plugin-react-svg et en cherchant un peu on a trouvé pas mal d’issues dans le meme cas, les svg n’étant pas utilisés en img mais en inline, les ids ne sont plus scopés au svg lui meme, mais globaux. Il reste une petite zone d’ombre de pourquoi ca ne crée pas plus d’erreurs, j’ai du enlever le minify et réécrire les ids du fichier à la main