### PR TITLE
discussion(z-index): Modals VS Toasts z-indexes

### DIFF
--- a/packages/andive/src/components/toast.js
+++ b/packages/andive/src/components/toast.js
@@ -61,7 +61,7 @@ const ToastContainerRoot = styled.div`
   pointer-events: none;
   position: fixed;
 
-  z-index: ${ZIndexes.MODALS};
+  z-index: ${ZIndexes.TOASTS};
 
   bottom: -${toastHeight}px;
   left: 0;

--- a/packages/andive/src/constants/enum.ts
+++ b/packages/andive/src/constants/enum.ts
@@ -3,5 +3,6 @@ export const ZIndexes = {
   ABSOLUTE: 50,
   FIXED: 100,
   MODALS: 150,
-  ERRORS: 300
+  ERRORS: 300,
+  TOASTS: 400
 }


### PR DESCRIPTION
J'ouvre une conversation sur la difference de z-index entre les toasts et les modals, en travaillant sur l'annulation multiple on a remarqué avec @rhavenz que les toasts d'erreurs apparaissaient en dessous de la modal de confirmation

## Comportement actuel
![Screenshot 2021-07-28 at 18 28 20](https://user-images.githubusercontent.com/19313367/127365053-4d7ef441-f039-4301-84bc-ac78dbaa56f3.png)

## Comportement attendu
![Screenshot 2021-07-28 at 18 28 34](https://user-images.githubusercontent.com/19313367/127365159-8ace60c4-59e9-47d0-b95f-610b96f7f7ef.png)

> ⚠️ &nbsp;&nbsp;&nbsp;Il me semble que certaines modals ont ce comportement sur l'order notamment

En regardant un peu plus je vois que dans l'app il arrive de faire des +1 / -1 sur des composants pour palier a ce problème 

![Screenshot 2021-07-28 at 18 26 44](https://user-images.githubusercontent.com/19313367/127365823-b7f7ba65-ec36-4332-afbf-5543afdc9436.png)

voici une solution parmi d'autres pour que les toasts soient toujours au dessus 😇
