### PR TITLE
feat(direction): implement a text (default) variant to align point and road with first line of a multi line address

### DIFF
--- a/docs/stories/direction.stories.js
+++ b/docs/stories/direction.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {storiesOf} from '@storybook/react'
-import {Direction, Input, Typography, Box, palette} from '@ambler/andive'
+import {Direction, DirectionVariant, Input, Typography, palette, VSpace} from '@ambler/andive'
 
 import Showcase from './showcase'
 
@@ -70,6 +70,7 @@ storiesOf('API|Direction', module)
               <Typography.Body1>Ambler</Typography.Body1>
             </Direction.Origin.Point>
             <Typography.Body2 color={palette.mediumPrimary}>24 Quai charles pasqua, Levalois-Perret</Typography.Body2>
+            <VSpace px={16} />
           </Direction.Origin>
           <Direction.Destination>
             <Direction.Destination.Point>
@@ -90,6 +91,7 @@ storiesOf('API|Direction', module)
               <Typography.Body1>Ambler</Typography.Body1>
             </Direction.Origin.Point>
             <Typography.Body2 color={palette.mediumPrimary}>24 Quai charles pasqua, Levalois-Perret</Typography.Body2>
+            <VSpace px={16} />
           </Direction.Origin>
           <Direction.Destination label={<Typography.Body1>~14:10</Typography.Body1>}>
             <Direction.Destination.Point>
@@ -109,6 +111,7 @@ storiesOf('API|Direction', module)
             <Typography.Body1>Ambler</Typography.Body1>
           </Direction.Origin.Point>
           <Typography.Body2 color={palette.mediumPrimary}>24 Quai charles pasqua, Levalois-Perret</Typography.Body2>
+          <VSpace px={16} />
         </Direction.Origin>
         <Direction.Destination>
           <Direction.Destination.Point>
@@ -155,7 +158,7 @@ storiesOf('API|Direction', module)
         </Direction>
       </Showcase>
       <Showcase>
-        <Direction style={{background: 'white'}} nopadding>
+        <Direction style={{background: 'white'}} nopadding variant={DirectionVariant.Centered}>
           <Direction.Origin>
             <Direction.Origin.Point>
               <div>

--- a/docs/stories/direction.stories.js
+++ b/docs/stories/direction.stories.js
@@ -159,21 +159,21 @@ storiesOf('API|Direction', module)
           <Direction.Origin>
             <Direction.Origin.Point>
               <div>
-                <Input label="Adresse" placeholder="Adresse d'origine" value="" onChange={() => null} />
+                <Input placeholder="Adresse d'origine" value="" onChange={() => null} />
               </div>
             </Direction.Origin.Point>
             <div style={{paddingLeft: 32}}>
-              <Input label="Origin" placeholder="Service" value="" onChange={() => null} />
+              <Input placeholder="Service" value="" onChange={() => null} />
             </div>
           </Direction.Origin>
           <Direction.Destination>
             <Direction.Destination.Point>
               <div>
-                <Input label="Adresse" placeholder="Adresse d'origine" value="" onChange={() => null} />
+                <Input placeholder="Adresse d'origine" value="" onChange={() => null} />
               </div>
             </Direction.Destination.Point>
             <div style={{paddingLeft: 32}}>
-              <Input label="Origin" placeholder="Service" value="" onChange={() => null} />
+              <Input placeholder="Service" value="" onChange={() => null} />
             </div>
           </Direction.Destination>
         </Direction>

--- a/docs/stories/direction.stories.js
+++ b/docs/stories/direction.stories.js
@@ -119,6 +119,33 @@ storiesOf('API|Direction', module)
       </Direction>
     </Showcase>
   ))
+  .add('Multiline', () => (
+    <>
+      <Showcase>
+        <Direction style={{background: 'white'}}>
+          <Direction.Origin label={<Typography.Body1>~14:10</Typography.Body1>}>
+            <Direction.Origin.Point>
+              <Typography.Body1>Ambler mais avec un nom à rallonge qui prends une place de fou</Typography.Body1>
+            </Direction.Origin.Point>
+            <Typography.Body2 color={palette.mediumPrimary}>
+              Et une adresse encore plus longue qui risque de prendre deux ou lignes sur un petit écran pour le besoin
+              de la demonstration
+            </Typography.Body2>
+            <VSpace px={16} />
+          </Direction.Origin>
+          <Direction.Destination label={<Typography.Body1>~14:10</Typography.Body1>}>
+            <Direction.Destination.Point>
+              <Typography.Body1>
+                La destination aussi est super longue, on teste un edge case mais c'est important. A voir si ça marche
+                du premier coup
+              </Typography.Body1>
+            </Direction.Destination.Point>
+            <Typography.Body2 color={palette.mediumPrimary}>Appart de Phil, Dives-sur-mer</Typography.Body2>
+          </Direction.Destination>
+        </Direction>
+      </Showcase>
+    </>
+  ))
   .add('Direction with any children', () => (
     <>
       <Showcase>

--- a/docs/stories/direction.stories.js
+++ b/docs/stories/direction.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import {storiesOf} from '@storybook/react'
-import {Direction, DirectionVariant, Input, Typography, palette, VSpace} from '@ambler/andive'
+import {Direction, Input, Typography, palette, VSpace} from '@ambler/andive'
 
 import Showcase from './showcase'
 
@@ -124,7 +124,7 @@ storiesOf('API|Direction', module)
   ))
   .add('Multiline', () => (
     <>
-      <Showcase>
+      <Showcase style={{maxWidth: '500px'}}>
         <Direction style={{background: 'white'}}>
           <Direction.Origin label={<Typography.Body1>~14:10</Typography.Body1>}>
             <Direction.Origin.Point>
@@ -152,13 +152,14 @@ storiesOf('API|Direction', module)
   .add('Direction with any children', () => (
     <>
       <Showcase>
-        <Direction label={'Heure inconnue'} style={{background: 'white'}}>
+        <Direction label={'Heure inconnue'} style={{background: 'white'}} variant={'centered'}>
           <Direction.Origin>Salut !</Direction.Origin>
+
           <Direction.Destination>Au revoir !</Direction.Destination>
         </Direction>
       </Showcase>
       <Showcase>
-        <Direction style={{background: 'white'}} nopadding variant={DirectionVariant.Centered}>
+        <Direction style={{background: 'white'}} nopadding variant={'centered'}>
           <Direction.Origin>
             <Direction.Origin.Point>
               <div>

--- a/packages/andive/src/components/direction/destination.tsx
+++ b/packages/andive/src/components/direction/destination.tsx
@@ -3,6 +3,7 @@ import styled, {css} from 'styled-components'
 
 import {isTypography} from '../typography'
 import * as palette from '../../constants/palette'
+import {DirectionVariant} from '.'
 
 const DestinationRoot = styled(({label, ...props}) => <div {...props} />)`
   position: relative;
@@ -24,28 +25,37 @@ const DestinationIconContent = styled.div`
   height: 100%;
 `
 
-const DestinationPoint = styled(({offsetY, ...props}) => <div {...props} />)`
+const DestinationPoint = styled(({offsetY, centered, ...props}) => <div {...props} />)`
   position: absolute;
 
   width: 8px;
   height: 8px;
 
   left: calc(50% - 4px);
-  top: ${props => props.offsetY || 4}px;
+  ${props => {
+    if (props.centered) {
+      return css`
+        top: ${props.offsetY || 4}px;
+      `
+    }
+    return css`
+      top: 8px;
+    `
+  }}
 
   border-radius: 50%;
 
   border: 2px solid ${palette.darkPrimary};
   background: white;
 `
-const DestinationRoad = styled(({offsetY, ...props}) => <div {...props} />)`
+const DestinationRoad = styled(({offsetY, centered, ...props}) => <div {...props} />)`
   position: absolute;
 
   left: calc(50% - 2px);
   width: 4px;
 
   ${props => {
-    if (props.offsetY) {
+    if (props.centered && props.offsetY) {
       return css`
         top: 0;
         height: ${props.offsetY + 4}px;
@@ -62,15 +72,13 @@ const DestinationRoad = styled(({offsetY, ...props}) => <div {...props} />)`
   background: ${palette.darkPrimary};
 `
 
-const AsideLabel = styled(({offsetY, ...props}) => <div {...props} />)`
+const AsideLabel = styled(({...props}) => <div {...props} />)`
   position: absolute;
-  top: ${props => (props.offsetY ? props.offsetY - 16 : -10)}px;
-  left: 0;
+  top: 0px;
+  left: -8px;
 
   width: 69px;
   min-height: 38px;
-
-  padding: 8px;
 
   text-align: right;
 `
@@ -94,8 +102,14 @@ interface DestinationProps<PointRefElementType> {
   className?: string
   label?: React.ReactNode
   children: React.ReactNode
+  variant: DirectionVariant
 }
-export function Destination<PointRefElementType>({label, children, ...props}: DestinationProps<PointRefElementType>) {
+export function Destination<PointRefElementType>({
+  label,
+  children,
+  variant,
+  ...props
+}: DestinationProps<PointRefElementType>) {
   const [rect, setRect] = React.useState<DOMRect | ClientRect>()
   const [pointRect, setPointRect] = React.useState<DOMRect | ClientRect>()
   const ref = React.useRef<HTMLDivElement>(null)
@@ -157,15 +171,17 @@ export function Destination<PointRefElementType>({label, children, ...props}: De
     offsetY = topToPointRef + pointRect.height / 2 - 4 - compensate
   }
 
+  const centered = variant === DirectionVariant.Centered
+
   return (
     <DestinationRoot label={label} {...props}>
       <DestinationIcon label={label}>
         <DestinationIconContent>
-          <DestinationRoad offsetY={offsetY} />
-          <DestinationPoint offsetY={offsetY} />
+          <DestinationRoad offsetY={offsetY} centered={centered} />
+          <DestinationPoint offsetY={offsetY} centered={centered} />
         </DestinationIconContent>
       </DestinationIcon>
-      {label && <AsideLabel offsetY={offsetY}>{label}</AsideLabel>}
+      {label && <AsideLabel>{label}</AsideLabel>}
       <div ref={ref}>
         <DestinationContext.Provider value={{ref: pointRef}}>{children}</DestinationContext.Provider>
       </div>

--- a/packages/andive/src/components/direction/destination.tsx
+++ b/packages/andive/src/components/direction/destination.tsx
@@ -34,13 +34,11 @@ const DestinationPoint = styled(({offsetY, centered, ...props}) => <div {...prop
   left: calc(50% - 4px);
   ${props => {
     if (props.centered) {
-      return css`
+      return `
         top: ${props.offsetY || 4}px;
       `
     }
-    return css`
-      top: 8px;
-    `
+    return 'top: 8px;'
   }}
 
   border-radius: 50%;
@@ -72,7 +70,7 @@ const DestinationRoad = styled(({offsetY, centered, ...props}) => <div {...props
   background: ${palette.darkPrimary};
 `
 
-const AsideLabel = styled(({...props}) => <div {...props} />)`
+const AsideLabel = styled.div`
   position: absolute;
   top: 0px;
   left: -8px;
@@ -171,7 +169,7 @@ export function Destination<PointRefElementType>({
     offsetY = topToPointRef + pointRect.height / 2 - 4 - compensate
   }
 
-  const centered = variant === DirectionVariant.Centered
+  const centered = variant === 'centered'
 
   return (
     <DestinationRoot label={label} {...props}>

--- a/packages/andive/src/components/direction/index.tsx
+++ b/packages/andive/src/components/direction/index.tsx
@@ -7,6 +7,11 @@ import Box from '../box'
 import {Origin} from './origin'
 import {Destination} from './destination'
 
+export enum DirectionVariant {
+  Text = 'Text',
+  Centered = 'Centered'
+}
+
 const DirectionRoot = styled(({fullWidth, nopadding, ...props}) => <div {...props} />)`
   min-width: ${props => (props.fullWidth ? '100%' : 'auto')};
   padding: ${props => (props.nopadding ? 0 : '8px')};
@@ -17,13 +22,21 @@ interface DirectionProps {
   fullWidth?: number
   nopadding?: boolean
   children?: any /* FixType */
+  variant?: DirectionVariant
 }
-export function Direction({children, label, fullWidth, nopadding, ...props}: DirectionProps) {
+export function Direction({
+  children,
+  label,
+  fullWidth,
+  nopadding,
+  variant = DirectionVariant.Text,
+  ...props
+}: DirectionProps) {
   return (
     <DirectionRoot fullWidth={fullWidth} nopadding={nopadding} {...props}>
       {label && <Box>{typeof label === 'string' ? <Typography.Body1>{label}</Typography.Body1> : label}</Box>}
       {React.Children.map(children, child => {
-        const childProps: {label?: string} = {}
+        const childProps: {label?: string; variant: DirectionVariant} = {variant}
         if (label) {
           childProps.label = ' '
         }

--- a/packages/andive/src/components/direction/index.tsx
+++ b/packages/andive/src/components/direction/index.tsx
@@ -7,10 +7,7 @@ import Box from '../box'
 import {Origin} from './origin'
 import {Destination} from './destination'
 
-export enum DirectionVariant {
-  Text = 'Text',
-  Centered = 'Centered'
-}
+export type DirectionVariant = 'text' | 'centered'
 
 const DirectionRoot = styled(({fullWidth, nopadding, ...props}) => <div {...props} />)`
   min-width: ${props => (props.fullWidth ? '100%' : 'auto')};
@@ -24,14 +21,7 @@ interface DirectionProps {
   children?: any /* FixType */
   variant?: DirectionVariant
 }
-export function Direction({
-  children,
-  label,
-  fullWidth,
-  nopadding,
-  variant = DirectionVariant.Text,
-  ...props
-}: DirectionProps) {
+export function Direction({children, label, fullWidth, nopadding, variant = 'text', ...props}: DirectionProps) {
   return (
     <DirectionRoot fullWidth={fullWidth} nopadding={nopadding} {...props}>
       {label && <Box>{typeof label === 'string' ? <Typography.Body1>{label}</Typography.Body1> : label}</Box>}

--- a/packages/andive/src/components/direction/origin.tsx
+++ b/packages/andive/src/components/direction/origin.tsx
@@ -33,13 +33,11 @@ const OriginPoint = styled(({offsetY, centered, ...props}) => <div {...props} />
   left: calc(50% - 4px);
   ${props => {
     if (props.centered) {
-      return css`
+      return `
         top: ${props.offsetY ? props.offsetY - 4 : 4}px;
       `
     }
-    return css`
-      top: 8px;
-    `
+    return 'top: 8px;'
   }}
 
   border-radius: 50%;
@@ -71,7 +69,7 @@ const OriginRoad = styled(({offsetY, centered, height, ...props}) => <div {...pr
   background: ${palette.darkPrimary};
 `
 
-const AsideLabel = styled(({...props}) => <div {...props} />)`
+const AsideLabel = styled.div`
   position: absolute;
 
   left: -8px;
@@ -158,7 +156,7 @@ export function Origin({className, label, children, variant}: OriginProps) {
   // Basic math: To get the center of the pointRef element we just:
   const offsetY = (pointRect && rect && pointRect.top - rect.top + pointRect.height / 2) || 0
 
-  const centered = variant === DirectionVariant.Centered
+  const centered = variant === 'centered'
 
   return (
     <OriginRoot className={className} label={label}>

--- a/packages/andive/src/components/direction/origin.tsx
+++ b/packages/andive/src/components/direction/origin.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled, {css} from 'styled-components'
+import {DirectionVariant} from '.'
 
 import * as palette from '../../constants/palette'
 
@@ -23,35 +24,44 @@ const OriginIconContent = styled.div`
   height: 100%;
 `
 
-const OriginPoint = styled(({offsetY, ...props}) => <div {...props} />)`
+const OriginPoint = styled(({offsetY, centered, ...props}) => <div {...props} />)`
   position: absolute;
 
   width: 8px;
   height: 8px;
 
   left: calc(50% - 4px);
-  top: ${props => (props.offsetY ? props.offsetY - 4 : 4)}px;
+  ${props => {
+    if (props.centered) {
+      return css`
+        top: ${props.offsetY ? props.offsetY - 4 : 4}px;
+      `
+    }
+    return css`
+      top: 8px;
+    `
+  }}
 
   border-radius: 50%;
 
   border: 2px solid ${palette.darkPrimary};
   background: white;
 `
-const OriginRoad = styled(({offsetY, height, ...props}) => <div {...props} />)`
+
+const OriginRoad = styled(({offsetY, centered, height, ...props}) => <div {...props} />)`
   position: absolute;
 
   left: calc(50% - 2px);
   width: 4px;
 
   ${props => {
-    if (props.offsetY) {
+    if (props.centered && props.offsetY) {
       return css`
         top: ${props.offsetY}px;
         height: ${props.height - props.offsetY}px;
       `
     }
 
-    // Old use-case. Should be removed.
     return css`
       top: 8px;
       height: ${props.height - 8}px;
@@ -61,15 +71,14 @@ const OriginRoad = styled(({offsetY, height, ...props}) => <div {...props} />)`
   background: ${palette.darkPrimary};
 `
 
-const AsideLabel = styled(({offsetY, ...props}) => <div {...props} />)`
+const AsideLabel = styled(({...props}) => <div {...props} />)`
   position: absolute;
-  top: ${props => (props.offsetY ? props.offsetY - 20 : -8)}px;
-  left: 0;
+
+  left: -8px;
+  top: 0px;
 
   width: 69px;
   min-height: 38px;
-
-  padding: 8px;
 
   text-align: right;
 `
@@ -93,9 +102,10 @@ type OriginProps = {
   className?: string
   label?: React.ReactNode
   children: React.ReactNode
+  variant: DirectionVariant
 }
 
-export function Origin({className, label, children}: OriginProps) {
+export function Origin({className, label, children, variant}: OriginProps) {
   const [rect, setRect] = React.useState<DOMRect | ClientRect>()
   const [pointRect, setPointRect] = React.useState<DOMRect | ClientRect>()
   const ref = React.useRef<HTMLDivElement>(null)
@@ -148,15 +158,17 @@ export function Origin({className, label, children}: OriginProps) {
   // Basic math: To get the center of the pointRef element we just:
   const offsetY = (pointRect && rect && pointRect.top - rect.top + pointRect.height / 2) || 0
 
+  const centered = variant === DirectionVariant.Centered
+
   return (
     <OriginRoot className={className} label={label}>
       <OriginIcon label={label} size={rect ? rect.height : 46}>
         <OriginIconContent>
-          <OriginRoad height={rect ? rect.height : 46} offsetY={offsetY} />
-          <OriginPoint offsetY={offsetY} />
+          <OriginRoad height={rect ? rect.height : 46} offsetY={offsetY} centered={centered} />
+          <OriginPoint offsetY={offsetY} centered={centered} />
         </OriginIconContent>
       </OriginIcon>
-      {label && <AsideLabel offsetY={offsetY}>{label}</AsideLabel>}
+      {label && <AsideLabel>{label}</AsideLabel>}
       <div ref={ref}>
         <OriginContext.Provider value={{ref: pointRef}}>{children}</OriginContext.Provider>
       </div>

--- a/packages/andive/src/index.tsx
+++ b/packages/andive/src/index.tsx
@@ -268,7 +268,7 @@ export {default as DialogTitle} from './components/dialog-title'
 
 export {default as Dialog} from './components/dialog'
 
-export {Direction, DirectionVariant} from './components/direction'
+export {Direction} from './components/direction'
 
 export {default as Dropdown} from './components/dropdown'
 

--- a/packages/andive/src/index.tsx
+++ b/packages/andive/src/index.tsx
@@ -268,7 +268,7 @@ export {default as DialogTitle} from './components/dialog-title'
 
 export {default as Dialog} from './components/dialog'
 
-export {Direction} from './components/direction'
+export {Direction, DirectionVariant} from './components/direction'
 
 export {default as Dropdown} from './components/dropdown'
 


### PR DESCRIPTION
This also fixes some of the miss-aligned labels as I replaced padding with positioning. 