### PR TITLE
fix(props): make variant prop optional for child components

### DIFF
--- a/packages/andive/src/components/direction/destination.tsx
+++ b/packages/andive/src/components/direction/destination.tsx
@@ -100,7 +100,7 @@ interface DestinationProps<PointRefElementType> {
   className?: string
   label?: React.ReactNode
   children: React.ReactNode
-  variant: DirectionVariant
+  variant?: DirectionVariant
 }
 export function Destination<PointRefElementType>({
   label,

--- a/packages/andive/src/components/direction/index.tsx
+++ b/packages/andive/src/components/direction/index.tsx
@@ -26,7 +26,7 @@ export function Direction({children, label, fullWidth, nopadding, variant = 'tex
     <DirectionRoot fullWidth={fullWidth} nopadding={nopadding} {...props}>
       {label && <Box>{typeof label === 'string' ? <Typography.Body1>{label}</Typography.Body1> : label}</Box>}
       {React.Children.map(children, child => {
-        const childProps: {label?: string; variant: DirectionVariant} = {variant}
+        const childProps: {label?: string; variant?: DirectionVariant} = {variant}
         if (label) {
           childProps.label = ' '
         }

--- a/packages/andive/src/components/direction/origin.tsx
+++ b/packages/andive/src/components/direction/origin.tsx
@@ -100,7 +100,7 @@ type OriginProps = {
   className?: string
   label?: React.ReactNode
   children: React.ReactNode
-  variant: DirectionVariant
+  variant?: DirectionVariant
 }
 
 export function Origin({className, label, children, variant}: OriginProps) {


### PR DESCRIPTION
The bug only appeared when used on the product. Works fine on the storybook somehow.

![Screenshot 2021-09-15 at 18 02 16](https://user-images.githubusercontent.com/11067297/133468545-e2af6b79-b267-438c-8985-8144c87dc6a0.png)
