### PR TITLE
fix(ui): fix direction points and routes alignment

### DIFF
--- a/docs/stories/direction.stories.js
+++ b/docs/stories/direction.stories.js
@@ -152,10 +152,17 @@ storiesOf('API|Direction', module)
   .add('Direction with any children', () => (
     <>
       <Showcase>
-        <Direction label={'Heure inconnue'} style={{background: 'white'}} variant={'centered'}>
-          <Direction.Origin>Salut !</Direction.Origin>
-
-          <Direction.Destination>Au revoir !</Direction.Destination>
+        <Direction label={'Heure inconnue'} style={{background: 'white'}}>
+          <Direction.Origin>
+            <Direction.Origin.Point>
+              <Typography.Body1>Salut !</Typography.Body1>
+            </Direction.Origin.Point>
+          </Direction.Origin>
+          <Direction.Destination>
+            <Direction.Destination.Point>
+              <Typography.Body1>Au revoir !</Typography.Body1>
+            </Direction.Destination.Point>
+          </Direction.Destination>
         </Direction>
       </Showcase>
       <Showcase>

--- a/packages/andive/src/components/direction/destination.tsx
+++ b/packages/andive/src/components/direction/destination.tsx
@@ -62,7 +62,7 @@ const DestinationRoad = styled(({offsetY, centered, ...props}) => <div {...props
 
     return css`
       top: 0;
-      height: 8px;
+      height: 12px;
     `
   }}
  

--- a/packages/andive/src/components/direction/origin.tsx
+++ b/packages/andive/src/components/direction/origin.tsx
@@ -61,7 +61,7 @@ const OriginRoad = styled(({offsetY, centered, height, ...props}) => <div {...pr
     }
 
     return css`
-      top: 8px;
+      top: 12px;
       height: ${props.height - 8}px;
     `
   }}


### PR DESCRIPTION
L'oeil de Lynx de Falgui a remarqué une regression dans le comportement du composant Direction qui ne se voit pas sans zoomer (ou d'avoir un 10/10 à chaque oeil)
https://amblerworkspace.slack.com/archives/CD4F6PNGY/p1632144733099900?thread_ts=1632142191.095500&cid=CD4F6PNGY

Force et Ambler