### PR TITLE
fix(button): inherit typography min-height

### DIFF
--- a/packages/andive/src/components/button.tsx
+++ b/packages/andive/src/components/button.tsx
@@ -76,6 +76,7 @@ const ButtonWrapper = styled.div.attrs({
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    min-height: inherit;
   }
 `
 


### PR DESCRIPTION
https://app.shortcut.com/ambler/story/6860/supprimer-le-min-height-de-la-typo-dans-les-boutons

https://user-images.githubusercontent.com/19313367/147081407-2c100774-8858-4d2c-bc40-aebfcd736ec4.mov

