### PR TITLE
feat(dropdownMenu): add defaultOpen and export DropDown

### DIFF
--- a/packages/andive/src/components/dropdown-menu.js
+++ b/packages/andive/src/components/dropdown-menu.js
@@ -99,8 +99,7 @@ function DropdownMenu({
   openVariant = OpenVariant.RIGHT,
   loading = false,
   noScroll = false,
-  defaultOpen = false,
-  defaultDropDownWidth = 'auto'
+  defaultOpen = false
 }) {
   const [open, setOpen] = React.useState(defaultOpen)
   const [fullWidth, setFullWidth] = React.useState(false)
@@ -179,11 +178,11 @@ function DropdownMenu({
         <OutsideClickHandler onOutsideClick={onClose}>
           <PoseGroup>
             <Dropdown
+              className="dropdown"
               key="dropdown"
               ref={dropdownRef}
               buttonLeft={buttonLeft}
               fullWidth={fullWidth}
-              defaultDropDownWidth={defaultDropDownWidth}
               openVariant={openVariant}
             >
               <Menu

--- a/packages/andive/src/components/dropdown-menu.js
+++ b/packages/andive/src/components/dropdown-menu.js
@@ -31,10 +31,10 @@ const Dropdown = styled(
 )`
   position: absolute;
 
-  ${({minWidth}) =>
-    minWidth &&
+  ${({defaultDropDownWidth}) =>
+    defaultDropDownWidth &&
     css`
-      min-width: ${minWidth};
+      width: ${defaultDropDownWidth};
     `}
   ${({openVariant}) => {
     if (openVariant === OpenVariant.LEFT) {
@@ -99,10 +99,10 @@ function DropdownMenu({
   openVariant = OpenVariant.RIGHT,
   loading = false,
   noScroll = false,
-  isOpen = false,
-  minWidth = 0
+  defaultOpen = false,
+  defaultDropDownWidth = 'auto'
 }) {
-  const [open, setOpen] = React.useState(isOpen)
+  const [open, setOpen] = React.useState(defaultOpen)
   const [fullWidth, setFullWidth] = React.useState(false)
 
   const dropdownRef = React.useRef(null)
@@ -183,7 +183,7 @@ function DropdownMenu({
               ref={dropdownRef}
               buttonLeft={buttonLeft}
               fullWidth={fullWidth}
-              minWidth={minWidth}
+              defaultDropDownWidth={defaultDropDownWidth}
               openVariant={openVariant}
             >
               <Menu

--- a/packages/andive/src/components/dropdown-menu.js
+++ b/packages/andive/src/components/dropdown-menu.js
@@ -31,11 +31,6 @@ const Dropdown = styled(
 )`
   position: absolute;
 
-  ${({defaultDropDownWidth}) =>
-    defaultDropDownWidth &&
-    css`
-      width: ${defaultDropDownWidth};
-    `}
   ${({openVariant}) => {
     if (openVariant === OpenVariant.LEFT) {
       return css`

--- a/packages/andive/src/components/dropdown-menu.js
+++ b/packages/andive/src/components/dropdown-menu.js
@@ -173,7 +173,6 @@ function DropdownMenu({
         <OutsideClickHandler onOutsideClick={onClose}>
           <PoseGroup>
             <Dropdown
-              className="dropdown"
               key="dropdown"
               ref={dropdownRef}
               buttonLeft={buttonLeft}
@@ -200,6 +199,7 @@ function DropdownMenu({
 DropdownMenu.Option = Menu.Option
 DropdownMenu.OptionGroup = Menu.OptionGroup
 DropdownMenu.OpenVariant = OpenVariant
+DropdownMenu.DropDown = Dropdown
 
 DropdownMenu.propTypes = {
   className: PropTypes.string,

--- a/packages/andive/src/components/dropdown-menu.js
+++ b/packages/andive/src/components/dropdown-menu.js
@@ -31,6 +31,11 @@ const Dropdown = styled(
 )`
   position: absolute;
 
+  ${({minWidth}) =>
+    minWidth &&
+    css`
+      min-width: ${minWidth};
+    `}
   ${({openVariant}) => {
     if (openVariant === OpenVariant.LEFT) {
       return css`
@@ -93,9 +98,11 @@ function DropdownMenu({
   buttonComponent = defaultButton,
   openVariant = OpenVariant.RIGHT,
   loading = false,
-  noScroll = false
+  noScroll = false,
+  isOpen = false,
+  minWidth = 0
 }) {
-  const [open, setOpen] = React.useState(false)
+  const [open, setOpen] = React.useState(isOpen)
   const [fullWidth, setFullWidth] = React.useState(false)
 
   const dropdownRef = React.useRef(null)
@@ -176,6 +183,7 @@ function DropdownMenu({
               ref={dropdownRef}
               buttonLeft={buttonLeft}
               fullWidth={fullWidth}
+              minWidth={minWidth}
               openVariant={openVariant}
             >
               <Menu


### PR DESCRIPTION
https://app.shortcut.com/ambler/story/6780/nettoyer-l-%C3%A9tape-raison-de-transport-sur-a4h

- isOpen : Pour permettre d'avoir le menu des raisons de transport ouvert
- minWidth : Pour permettre de passer une taille minimum