### PR TITLE
feat(dropdown-filter): remove overlay if transparent (allows scroll outside active element)

### DIFF
--- a/packages/andive/src/components/dropdown-filter.tsx
+++ b/packages/andive/src/components/dropdown-filter.tsx
@@ -69,8 +69,6 @@ export const PageOverlay = styled.div`
 
   background: rgba(255, 255, 255, 0.8);
   z-index: ${ZIndexes.MODALS};
-
-  border: 1px solid tomato;
 `
 
 const MobileHeader = styled.div`

--- a/packages/andive/src/components/dropdown-filter.tsx
+++ b/packages/andive/src/components/dropdown-filter.tsx
@@ -132,7 +132,6 @@ interface MenuFilterProps {
   transparent?: boolean
   openByDefault?: boolean
 }
-
 export function DropdownFilter({
   className,
   label,

--- a/packages/andive/src/components/dropdown-filter.tsx
+++ b/packages/andive/src/components/dropdown-filter.tsx
@@ -165,43 +165,9 @@ export function DropdownFilter({
     }
   }, [])
 
-  const menuJsx = (
-    <Menu className={className} openLeft={openLeft} mobile={mobile}>
-      {mobile && (
-        <MobileHeader>
-          {title && <H2>{title}</H2>}
-          <MobileHeaderIconRight>
-            <CloseIcon onClick={onCloseOnly} color={palette.darkBerryBlue} />
-          </MobileHeaderIconRight>
-        </MobileHeader>
-      )}
-      {mobile && onClear && (
-        <MobileActions>
-          <Button variant="flat" label="Tout effacer" onClick={onClear} />
-        </MobileActions>
-      )}
-      {typeof children === 'function' ? children({close: onCloseOnly}) : children}
-
-      {mobile
-        ? onSave && (
-            <StickyFooter>
-              <Button variant="primary" label="Enregistrer" onClick={onCloseAndSave} />
-            </StickyFooter>
-          )
-        : (onClear || onSave) && (
-            <Actions>
-              {onClear && (
-                <Button variant="flat" textColor={palette.darkPrimary} label="Tout effacer" onClick={onClear} />
-              )}
-              {onSave && <Button variant="flat" label="Enregistrer" onClick={onCloseAndSave} />}
-            </Actions>
-          )}
-    </Menu>
-  )
-
   return (
     <>
-      {open && !transparent && <PageOverlay onClick={onCloseAndSave} />}
+      {open && !transparent && <PageOverlay />}
       <MenuFilterRoot open={open}>
         {button &&
           React.cloneElement(button, {
@@ -211,12 +177,41 @@ export function DropdownFilter({
             active: open || selected
           })}
         {!button && <FilterButton active={selected || open} label={label} onClick={onClick} />}
-        {open &&
-          (transparent ? (
-            <OutsideClickHandler onOutsideClick={onCloseAndSave}>{menuJsx}</OutsideClickHandler>
-          ) : (
-            menuJsx
-          ))}
+        {open && (
+          <OutsideClickHandler onOutsideClick={onCloseAndSave}>
+            <Menu className={className} openLeft={openLeft} mobile={mobile}>
+              {mobile && (
+                <MobileHeader>
+                  {title && <H2>{title}</H2>}
+                  <MobileHeaderIconRight>
+                    <CloseIcon onClick={onCloseOnly} color={palette.darkBerryBlue} />
+                  </MobileHeaderIconRight>
+                </MobileHeader>
+              )}
+              {mobile && onClear && (
+                <MobileActions>
+                  <Button variant="flat" label="Tout effacer" onClick={onClear} />
+                </MobileActions>
+              )}
+              {typeof children === 'function' ? children({close: onCloseOnly}) : children}
+
+              {mobile
+                ? onSave && (
+                    <StickyFooter>
+                      <Button variant="primary" label="Enregistrer" onClick={onCloseAndSave} />
+                    </StickyFooter>
+                  )
+                : (onClear || onSave) && (
+                    <Actions>
+                      {onClear && (
+                        <Button variant="flat" textColor={palette.darkPrimary} label="Tout effacer" onClick={onClear} />
+                      )}
+                      {onSave && <Button variant="flat" label="Enregistrer" onClick={onCloseAndSave} />}
+                    </Actions>
+                  )}
+            </Menu>
+          </OutsideClickHandler>
+        )}
       </MenuFilterRoot>
     </>
   )

--- a/packages/andive/src/components/dropdown-filter.tsx
+++ b/packages/andive/src/components/dropdown-filter.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled, {css} from 'styled-components'
+import OutsideClickHandler from 'react-outside-click-handler'
 
 import * as palette from '../constants/palette'
 import Button from './button'
@@ -58,7 +59,7 @@ const Actions = styled.div`
   padding: 24px 8px;
 `
 
-export const PageOverlay = styled.div<{$transparent?: boolean}>`
+export const PageOverlay = styled.div`
   position: fixed;
 
   top: 0;
@@ -66,8 +67,10 @@ export const PageOverlay = styled.div<{$transparent?: boolean}>`
   width: 100%;
   height: 100%;
 
-  background: ${props => (props.$transparent ? 'transparent' : 'rgba(255, 255, 255, 0.8)')};
+  background: rgba(255, 255, 255, 0.8);
   z-index: ${ZIndexes.MODALS};
+
+  border: 1px solid tomato;
 `
 
 const MobileHeader = styled.div`
@@ -131,6 +134,7 @@ interface MenuFilterProps {
   transparent?: boolean
   openByDefault?: boolean
 }
+
 export function DropdownFilter({
   className,
   label,
@@ -163,9 +167,43 @@ export function DropdownFilter({
     }
   }, [])
 
+  const menu = (
+    <Menu className={className} openLeft={openLeft} mobile={mobile}>
+      {mobile && (
+        <MobileHeader>
+          {title && <H2>{title}</H2>}
+          <MobileHeaderIconRight>
+            <CloseIcon onClick={onCloseOnly} color={palette.darkBerryBlue} />
+          </MobileHeaderIconRight>
+        </MobileHeader>
+      )}
+      {mobile && onClear && (
+        <MobileActions>
+          <Button variant="flat" label="Tout effacer" onClick={onClear} />
+        </MobileActions>
+      )}
+      {typeof children === 'function' ? children({close: onCloseOnly}) : children}
+
+      {mobile
+        ? onSave && (
+            <StickyFooter>
+              <Button variant="primary" label="Enregistrer" onClick={onCloseAndSave} />
+            </StickyFooter>
+          )
+        : (onClear || onSave) && (
+            <Actions>
+              {onClear && (
+                <Button variant="flat" textColor={palette.darkPrimary} label="Tout effacer" onClick={onClear} />
+              )}
+              {onSave && <Button variant="flat" label="Enregistrer" onClick={onCloseAndSave} />}
+            </Actions>
+          )}
+    </Menu>
+  )
+
   return (
     <>
-      {open && <PageOverlay onClick={onCloseAndSave} $transparent={transparent} />}
+      {open && !transparent && <PageOverlay onClick={onCloseAndSave} />}
       <MenuFilterRoot open={open}>
         {button &&
           React.cloneElement(button, {
@@ -175,39 +213,8 @@ export function DropdownFilter({
             active: open || selected
           })}
         {!button && <FilterButton active={selected || open} label={label} onClick={onClick} />}
-        {open && (
-          <Menu className={className} openLeft={openLeft} mobile={mobile}>
-            {mobile && (
-              <MobileHeader>
-                {title && <H2>{title}</H2>}
-                <MobileHeaderIconRight>
-                  <CloseIcon onClick={onCloseOnly} color={palette.darkBerryBlue} />
-                </MobileHeaderIconRight>
-              </MobileHeader>
-            )}
-            {mobile && onClear && (
-              <MobileActions>
-                <Button variant="flat" label="Tout effacer" onClick={onClear} />
-              </MobileActions>
-            )}
-            {typeof children === 'function' ? children({close: onCloseOnly}) : children}
-
-            {mobile
-              ? onSave && (
-                  <StickyFooter>
-                    <Button variant="primary" label="Enregistrer" onClick={onCloseAndSave} />
-                  </StickyFooter>
-                )
-              : (onClear || onSave) && (
-                  <Actions>
-                    {onClear && (
-                      <Button variant="flat" textColor={palette.darkPrimary} label="Tout effacer" onClick={onClear} />
-                    )}
-                    {onSave && <Button variant="flat" label="Enregistrer" onClick={onCloseAndSave} />}
-                  </Actions>
-                )}
-          </Menu>
-        )}
+        {open &&
+          (transparent ? <OutsideClickHandler onOutsideClick={onCloseAndSave}>{menu}</OutsideClickHandler> : menu)}
       </MenuFilterRoot>
     </>
   )

--- a/packages/andive/src/components/dropdown-filter.tsx
+++ b/packages/andive/src/components/dropdown-filter.tsx
@@ -165,7 +165,7 @@ export function DropdownFilter({
     }
   }, [])
 
-  const menu = (
+  const menuJsx = (
     <Menu className={className} openLeft={openLeft} mobile={mobile}>
       {mobile && (
         <MobileHeader>
@@ -212,7 +212,11 @@ export function DropdownFilter({
           })}
         {!button && <FilterButton active={selected || open} label={label} onClick={onClick} />}
         {open &&
-          (transparent ? <OutsideClickHandler onOutsideClick={onCloseAndSave}>{menu}</OutsideClickHandler> : menu)}
+          (transparent ? (
+            <OutsideClickHandler onOutsideClick={onCloseAndSave}>{menuJsx}</OutsideClickHandler>
+          ) : (
+            menuJsx
+          ))}
       </MenuFilterRoot>
     </>
   )


### PR DESCRIPTION
Au lieu de lui mettre un background color transparent, cette PR retire le overlay de `DropdownFilter` lorsque la props `transparent` est `true`.

Cela semble résoudre le problème de scroll (ticket associé) avec un side-effect souhaitable (cit. Gix): rendre clickables les éléments autour de l'élément actif (voir enregistrement en bas).

https://user-images.githubusercontent.com/25111339/229157154-259ad8d2-8334-47ed-8b4d-41df03cc26ff.mov

Le comportement ne change pas lorsque la prop `transparent` est `false`: le overlay est affiché et empêche de cliquer sur les éléments en-dessous.